### PR TITLE
修复由于Activiti新版本createUserTaskActivityBehavior方法修改造成的参数传递null会报空指针异常问题

### DIFF
--- a/openwebflow-core/src/main/java/org/openwebflow/ctrl/creator/RuntimeActivityCreatorSupport.java
+++ b/openwebflow-core/src/main/java/org/openwebflow/ctrl/creator/RuntimeActivityCreatorSupport.java
@@ -49,9 +49,7 @@ public abstract class RuntimeActivityCreatorSupport
 			taskDefinition.setAssigneeExpression(new FixedValue(assignee));
 		}
 
-		UserTaskActivityBehavior cloneActivityBehavior = ((ProcessEngineConfigurationImpl) processEngine
-				.getProcessEngineConfiguration()).getActivityBehaviorFactory().createUserTaskActivityBehavior(null,
-			taskDefinition);
+		UserTaskActivityBehavior cloneActivityBehavior = new UserTaskActivityBehavior(null, taskDefinition);
 		clone.setActivityBehavior(cloneActivityBehavior);
 
 		return clone;


### PR DESCRIPTION
Activiti 新版本中 `createUserTaskActivityBehavior`方法更新为
 `return new UserTaskActivityBehavior(userTask.getId(), taskDefinition);`如传入`Usertask`为空会报空指针异常。